### PR TITLE
Add 'use strict'

### DIFF
--- a/app/hungarianOn3.js
+++ b/app/hungarianOn3.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var BitSet = require('fast-bitset');
 
 /**


### PR DESCRIPTION
`'use strict'` statement fixes some problems in javascript. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode

